### PR TITLE
Create X11.md

### DIFF
--- a/_intent_specs/x11.md
+++ b/_intent_specs/x11.md
@@ -1,20 +1,9 @@
 ---
 title: Start an X11 Server
 description: This intention is used to allow X11 applications to be able to launch an X server as a prerrequisite for other applications.
-action: x11
-constant: android.content.Intent.ACTION_VIEW
+action: android.intent.action.VIEW
 uri: x11://host:port. 
 link: http://docs.theqvd.com/docs/android.html#_x_server
-extras:
-  - name: host
-    type: String
-    description: the IP where the X11 will bind to
-    var: hostname
-    sample: "localhost", "127.0.0.1"
-  - name: port
-    type: Int
-    description: this is the port where the X11 server is listening, that is 6000 by default. Note: tcp port 6000 is usually DISPLAY=:0
-    sample: 6000
 author: Nito Martinez
 submitted: 2016-05-20
 ---

--- a/_intent_specs/x11.md
+++ b/_intent_specs/x11.md
@@ -1,8 +1,8 @@
 ---
 title: Start an X11 Server
-description: This intention is used to allow X11 applications to be able to launch an X server as a prerrequisite for other applications.
+description: This intention is used to allow X11 applications to be able to launch an X server as a prerrequisite for other applications. The URI is specified as, for example, x11://localhost:6000, where usually localhost is the bind address and 6000 means a port number ... An uri of x11://localhost:6100 would usually mean that the environment variable DISPLAY for the application would have been set to DISPLAY=localhost:100. 
 action: android.intent.action.VIEW
-uri: x11://host:port. 
+uri: x11://host:port
 link: http://docs.theqvd.com/docs/android.html#_x_server
 author: Nito Martinez
 submitted: 2016-05-20

--- a/_intent_specs/x11.md
+++ b/_intent_specs/x11.md
@@ -1,0 +1,41 @@
+---
+title: Start an X11 Server
+description: This intention is used to allow X11 applications to be able to launch an X server as a prerrequisite for other applications.
+action: x11
+constant: android.content.Intent.ACTION_VIEW
+uri: x11://host:port. 
+link: http://docs.theqvd.com/docs/android.html#_x_server
+extras:
+  - name: host
+    type: String
+    description: the IP where the X11 will bind to
+    var: hostname
+    sample: "localhost", "127.0.0.1"
+  - name: port
+    type: Int
+    description: this is the port where the X11 server is listening, that is 6000 by default. Note: tcp port 6000 is usually DISPLAY=:0
+    sample: 6000
+author: Nito Martinez
+submitted: 2016-05-20
+---
+description: This intent is used to allow X11 applications to be able to launch an X server as a prerrequisite for other applications.
+code: |
+  public class MainActivity extends Activity {
+    private Button buttonLaunchX;
+    static final String tag = "XtestIntent-MainActivity-" +java.util.Map.Entry.class.getSimpleName();
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+       super.onCreate(savedInstanceState);
+       setContentView(R.layout.main);
+       buttonLaunchX = (Button) findViewById(R.id.button1);
+       buttonLaunchX.setOnClickListener(new Button.OnClickListener() {
+                            public void onClick(View view) {
+                                    String cmd = "x11://localhost:0";
+                                      Log.i(tag, "launching intent:"+cmd);
+                                            Intent x11Intent = new Intent(android.content.Intent.ACTION_VIEW, Uri.parse(cmd));
+                                                  startService(x11Intent);
+                                            }
+       });
+    }
+  }
+


### PR DESCRIPTION
This intent is used to allow X11 applications to be able to launch an X server as a prerrequisite for other applications.

Please see http://docs.theqvd.com/docs/android.html#_x_server for more info.

This intent used to be described at http://www.openintents.org/~oi/node/905

It is currently used (AFAIK) by QVD http://theqvd.com
And implemented by:


 * XSDL X server https://play.google.com/store/apps/details?id=x.org.server
 * Darkside X server https://play.google.com/store/apps/details?id=au.com.darkside.XServer
 * Xvncpro X server https://play.google.com/store/apps/details?id=com.theqvd.android.xpro